### PR TITLE
Alternative to encode Window types

### DIFF
--- a/src/lib/getNostoWindow.ts
+++ b/src/lib/getNostoWindow.ts
@@ -1,5 +1,3 @@
-import { NostoWindow } from "../types"
-
 export function getNostoWindow() {
-  return (window.nosto as NostoWindow) ?? undefined
+  return window.nosto
 }

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,17 +1,4 @@
 interface Window {
-  fbq: (...args: unknown[]) => void
-
-  // nosto additions
-  _targetWindow: Window
-  nosto: Window
-  nostoab: { settings: Settings }
-  nostojs: nostojs
-  reload: (options: Partial<Settings>) => void
-
-  // Search additions
-  nostoTemplatesLoaded: boolean
-  nostoTemplatesConfig: {
-    merchant: string
-    defaultCurrency: string
-  }
+  nosto?: import("./types").NostoSandbox
+  nostojs: import("./client/nosto").nostojs
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,20 +2,12 @@ import { nostojs, Settings } from "./client/nosto"
 
 export type BackendEnvironment = "production" | "staging" | "local"
 
-export type NostoWindow = Window & {
-  fbq: (...args: unknown[]) => void
-
-  // nosto additions
-  _targetWindow: Window
-  nosto: Window
-  nostoab: { settings: Settings }
+export type MainWindow = Window & {
+  nosto?: NostoSandbox
   nostojs: nostojs
-  reload: (options: Partial<Settings>) => void
+}
 
-  // Search additions
-  nostoTemplatesLoaded: boolean
-  nostoTemplatesConfig: {
-    merchant: string
-    defaultCurrency: string
-  }
+export type NostoSandbox = Window & {
+  _targetWindow: MainWindow
+  reload: (options: Partial<Settings>) => void
 }


### PR DESCRIPTION
Simplify and split Window types
Also remove fields in window scope that are mainly to be used internally to the client script