### PR TITLE
Drop setPageType functionality

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,15 +1,4 @@
-import { API, PageType } from "../client/nosto"
-
-export function setPageType(pageType: PageType) {
-  document.querySelectorAll(".nosto_page_type").forEach(el => el.remove())
-
-  const div = document.createElement("div")
-  div.classList.add("nosto_page_type")
-  div.style.display = "none"
-  div.textContent = pageType
-  div.translate = false
-  document.body.appendChild(div)
-}
+import { API } from "../client/nosto"
 
 export function initNostoStub() {
   window.nostojs =


### PR DESCRIPTION
Drop setPageType functionality, since we want to be quite neutral regarding what kind of context submission to use with this wrapper library

The alternatives to tagging are
* Session API (api.defaultSession()....)
* tagging providers
* direct RequestBuilder usage (api.createRecommendationRequest())