### PR TITLE
fix: make nostojs less prone to crashing

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,9 +1,11 @@
 import type { Settings } from "../client/nosto"
+import { initNostoStub } from "../utils/dom"
 import { nostojs } from "./nostojs"
 
 let settings: Settings | null = null
 
 if (typeof window !== "undefined") {
+  initNostoStub()
   nostojs(api => {
     settings = api.internal.getSettings()
   })


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The app/test won't crash if nostojs is called in an unexpected spot.

## Related Jira ticket

<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Documentation

<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots

<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->
