### PR TITLE
fix: remove NPMJS_TOKEN usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

This pull request makes a minor update to the GitHub Actions workflow configuration. The change removes the `NPM_TOKEN` environment variable from the release job, likely because it is no longer needed for this workflow.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
