### PR TITLE
fix: use GITHUB_TOKEN instead of RELEASE_PAT_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
               "main"
             ]
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-docs:
     needs: release


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes a small change to the GitHub Actions workflow by updating the authentication token used for releases. The workflow now uses the default `GITHUB_TOKEN` instead of a repository secret for publishing.

- Updated the `GITHUB_TOKEN` in `.github/workflows/release.yml` from a custom secret (`RELEASE_PAT_TOKEN`) to the default GitHub Actions token (`GITHUB_TOKEN`).

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
