### PR TITLE
fix: revert to PAT token usage with read contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         id: semantic
         with:
-          semantic_version: 25.0.1
+          semantic_version: 25.0.2
           extra_plugins: |
             @semantic-release/git
           branches: |


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request updates the release workflow configuration to use a specific semantic release version and changes the authentication token for publishing releases.

Release workflow updates:

* Updated the `semantic_version` to `25.0.2` in the semantic release action configuration in `.github/workflows/release.yml`, ensuring the workflow uses a consistent and up-to-date version.
* Changed the environment variable from `GITHUB_TOKEN` to `RELEASE_PAT_TOKEN` for authentication, improving security and control over release permissions.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
