### PR TITLE
fix: add repository url in package.json for trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Nosto/nosto-js.git"
+    "url": "git+https://github.com/Nosto/nosto-js.git"
   }
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes a small update to the `package.json` file by adding repository metadata. This helps clarify the project's source location and version control system.

* Added a `repository` field specifying the type as `git` and the URL as `https://github.com/Nosto/nosto-js.git` in `package.json`.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
