### PR TITLE
Remove npm audit from GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run build
         run: npm run build
 
@@ -42,9 +39,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run build
         run: npm run build
 
@@ -82,9 +79,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-  
       - run: npm run build
 
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- remove npm audit steps from CI build and lint jobs
- remove npm audit steps from release and docs publishing jobs

## Verification
- rg -n "npm audit|npm-audit|audit" .github